### PR TITLE
making the recursive write_json calls include templated params passed…

### DIFF
--- a/include/json_msgpack/json_msgpack_sax.hpp
+++ b/include/json_msgpack/json_msgpack_sax.hpp
@@ -309,7 +309,7 @@ inline bool write_json(Writer& writer, const msgpack::object& o)
             msgpack::object* ptr = o.via.array.ptr;
             msgpack::object* end = ptr + o.via.array.size;
             for (; ptr < end; ++ptr) {
-                if (!write_json(writer, *ptr)) {
+                if (!write_json<Writer, StringConversion>(writer, *ptr)) {
                     return false;
                 }
             }
@@ -324,10 +324,10 @@ inline bool write_json(Writer& writer, const msgpack::object& o)
                 // Writer::Key() is a synonym of Writer::String() so we can delegate.
                 // The SAX API will likely complain if the key is not a string, but we
                 // can offload that responsibility instead of ensuring it ourselves.
-                if (!write_json(writer, ptr->key)) {
+                if (!write_json<Writer, StringConversion>(writer, ptr->key)) {
                     return false;
                 }
-                if (!write_json(writer, ptr->val)) {
+                if (!write_json<Writer, StringConversion>(writer, ptr->val)) {
                     return false;
                 }
             }


### PR DESCRIPTION
… to the original function.  This is what I talked about discovering in the comments to #33.  Without this, the `no_custom_string_conversion` function gets unintentionally called in the serialization process even when the wamp specific routines are passed in from bonefish's [json_serializer.cpp](https://github.com/davidchappelle/bonefish/blob/feature/progressive_call_results/src/bonefish/serialization/json_serializer.cpp).

[Link to previous discussion](https://github.com/tplgy/bonefish/issues/33#issuecomment-180060672)
